### PR TITLE
fix replace avatar url option according to coding standards

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1453,8 +1453,8 @@ Application::Application(
     // If someone specifies both --avatarURL and --replaceAvatarURL,
     // the replaceAvatarURL wins.  So only set the _overrideUrl if this
     // does have a non-empty string.
-    if (parser.isSet("replace-avatar-url")) {
-        QString replaceURL = parser.value("replace-avatar-url");
+    if (parser.isSet("replaceAvatarURL")) {
+        QString replaceURL = parser.value("replaceAvatarURL");
         _avatarOverrideUrl = QUrl::fromUserInput(replaceURL);
         _saveAvatarOverrideUrl = true;
     }

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -161,7 +161,7 @@ int main(int argc, const char* argv[]) {
         "url"
     );
     QCommandLineOption replaceAvatarURLOption(
-        "replace-avatar-url",
+        "replaceAvatarURL",
         "Replaces the avatar U.R.L. When used with --avatarURL, this takes precedence.",
         "url"
     );


### PR DESCRIPTION
Coding standard says that it should be `replaceAvatarURL` like in the comments above.